### PR TITLE
0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.6.7]
+
+* Issues:
+  Fix issue that ExtendedImageGesturePageView didn't work well when set initial alignment.
+
 ## [0.6.6]
 
 * Features:

--- a/lib/src/extended_image.dart
+++ b/lib/src/extended_image.dart
@@ -831,17 +831,8 @@ class _ExtendedImageState extends State<ExtendedImage>
         switch (_loadState) {
           case LoadState.loading:
             current = Container(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  _getIndicator(context),
-                  SizedBox(
-                    width: 5.0,
-                  ),
-                  Text("loading...")
-                ],
-              ),
+              alignment: Alignment.center,
+              child: _getIndicator(context),
             );
             break;
           case LoadState.completed:

--- a/lib/src/gesture/extended_image_gesture_utils.dart
+++ b/lib/src/gesture/extended_image_gesture_utils.dart
@@ -264,6 +264,7 @@ class GestureDetails {
 
   Rect _innerCalculateFinalDestinationRect(
       Rect layoutRect, Rect destinationRect) {
+    _boundary = Boundary();
     Offset center = _getCenter(destinationRect);
     Rect result = _getDestinationRect(destinationRect, center);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: extended_image
 description: Official extension image, support placeholder(loading)/ failed state, cache network, zoom/pan, photo view, slide out page, editor(crop,rotate,flip), painting etc.
-version: 0.6.6
+version: 0.6.7
 author: zmtzawqlp <zmtzawqlp@live.com>
 homepage: https://github.com/fluttercandies/extended_image
 


### PR DESCRIPTION
  Fix issue(https://github.com/fluttercandies/extended_image/issues/66) that ExtendedImageGesturePageView didn't work well when set initial alignment.