### PR TITLE
feat(slide)：Customize the offset when sliding. 

### DIFF
--- a/lib/src/extended_image_typedef.dart
+++ b/lib/src/extended_image_typedef.dart
@@ -34,6 +34,9 @@ typedef DoubleTap = void Function(ExtendedImageGestureState state);
 typedef SlidePageBackgroundHandler = Color Function(
     Offset offset, Size pageSize);
 
+/// custom offset of page when slide page
+typedef SlideOffsetHanlder = Offset Function(Offset offset);
+
 ///if return true ,pop page
 ///else reset page state
 typedef SlideEndHandler = bool Function(Offset offset);

--- a/lib/src/gesture/extended_image_slide_page.dart
+++ b/lib/src/gesture/extended_image_slide_page.dart
@@ -25,6 +25,9 @@ class ExtendedImageSlidePage extends StatefulWidget {
   ///builder of page background when slide page
   final SlideScaleHandler slideScaleHandler;
 
+  ///change offset when slide page
+  final SlideOffsetHanlder slideOffsetHandler;
+
   ///call back of slide end
   ///decide whether pop page
   final SlideEndHandler slideEndHandler;
@@ -133,6 +136,7 @@ class ExtendedImageSlidePageState extends State<ExtendedImageSlidePage>
     } else if (widget.slideAxis == SlideAxis.vertical) {
       _offset = Offset(0.0, value.dy);
     }
+    _offset = widget.slideOffsetHandler?.call(_offset) ?? _offset;
 
     _scale = widget.slideScaleHandler?.call(_offset) ??
         defaultSlideScaleHandler(

--- a/lib/src/gesture/extended_image_slide_page.dart
+++ b/lib/src/gesture/extended_image_slide_page.dart
@@ -49,6 +49,7 @@ class ExtendedImageSlidePage extends StatefulWidget {
     this.child,
     this.slidePageBackgroundHandler,
     this.slideScaleHandler,
+    this.slideOffsetHandler,
     this.slideEndHandler,
     this.slideAxis: SlideAxis.both,
     this.resetPageDuration: const Duration(milliseconds: 500),


### PR DESCRIPTION
e.g: just like the iOS Album or WeChat, it only closes the picture when you slide it down at the top of it, when you slide it up at the end of the pic, you don't need to move its dx.

```
      slidePageBackgroundHandler: (offset, size) {
        double distance = offset.dy > 0 ? offset.distance * 0.003 : 0.0;
        double opacity = max(1.0 - distance, 0.1);
        return Color(0xFF131415).withOpacity(opacity);
      },
      slideScaleHandler: (Offset offset) => offset.dy > 0
          ? defaultSlideScaleHandler(
              offset: offset,
              pageSize: context.size,
              pageGestureAxis: SlideAxis.both)
          : 1,
      slideOffsetHandler: (Offset offset) =>
          offset.dy > 0 ? offset : Offset(0, offset.dy),
      slideEndHandler: (Offset offset) => offset.dy > 100.0,
```