### PR TITLE
fix: Fixed floating point comparison error. 

### DIFF
--- a/lib/src/editor/extended_image_crop_layer.dart
+++ b/lib/src/editor/extended_image_crop_layer.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 import 'extended_image_editor_utils.dart';
+import '../extended_image_utils.dart';
 
 ///
 ///  create by zhoumaotuo on 2019/8/22

--- a/lib/src/editor/extended_image_crop_layer.dart
+++ b/lib/src/editor/extended_image_crop_layer.dart
@@ -322,10 +322,10 @@ class ExtendedImageCropLayerState extends State<ExtendedImageCropLayer>
         gWidth, moveType, result, layerDestinationRect, delta);
 
     ///move and scale image rect when crop rect is bigger than layout rect
-    if (result.left < layoutRect.left ||
-        result.right > layoutRect.right ||
-        result.top < layoutRect.top ||
-        result.bottom > layoutRect.bottom) {
+    if (doubleCompare(result.left, layoutRect.left) < 0 ||
+        doubleCompare(result.right, layoutRect.right) > 0 ||
+        doubleCompare(result.top, layoutRect.top) < 0 ||
+        doubleCompare(result.bottom, layoutRect.bottom) > 0) {
       cropRect = result;
       var centerCropRect = getDestinationRect(
           rect: layoutRect, inputSize: result.size, fit: widget.fit);
@@ -373,7 +373,7 @@ class ExtendedImageCropLayerState extends State<ExtendedImageCropLayer>
           var dy = delta.dy.abs();
           var width = result.width;
           var height = result.height;
-          if (dx >= dy) {
+          if (doubleCompare(dx, dy) >= 0) {
             height = max(minD,
                 min(result.width / aspectRatio, layerDestinationRect.height));
             width = height * aspectRatio;
@@ -448,9 +448,9 @@ class ExtendedImageCropLayerState extends State<ExtendedImageCropLayer>
     var scale = newScreenCropRect.width / oldScreenCropRect.width;
 
     var totalScale = widget.editActionDetails.totalScale * scale;
-    if (totalScale > widget.editorConfig.maxScale) {
-      if (rect.width > cropRect.width || rect.height > cropRect.height)
-        return rect;
+    if (doubleCompare(totalScale, widget.editorConfig.maxScale) > 0) {
+      if (doubleCompare(rect.width, cropRect.width) > 0 ||
+          doubleCompare(rect.height, cropRect.height) > 0) return rect;
       return null;
     }
 

--- a/lib/src/editor/extended_image_editor.dart
+++ b/lib/src/editor/extended_image_editor.dart
@@ -148,11 +148,12 @@ class ExtendedImageEditorState extends State<ExtendedImageEditor> {
                       _editorConfig.cropAspectRatio != null &&
                       _editorConfig.cropAspectRatio > 0) {
                     var rect = _initCropRect(layoutRect);
-                    _editActionDetails.totalScale =
-                        _editActionDetails.preTotalScale =
-                            destinationRect.width > destinationRect.height
-                                ? rect.height / cropRect.height
-                                : rect.width / cropRect.width;
+                    _editActionDetails.totalScale = _editActionDetails
+                        .preTotalScale = doubleCompare(
+                                destinationRect.width, destinationRect.height) >
+                            0
+                        ? rect.height / cropRect.height
+                        : rect.width / cropRect.width;
                     cropRect = rect;
                   }
                   _editActionDetails.cropRect = cropRect;
@@ -225,8 +226,10 @@ class ExtendedImageEditorState extends State<ExtendedImageEditor> {
         (
             // (_editActionDetails.totalScale == _editorConfig.minScale &&
             //       totalScale <= _editActionDetails.totalScale) ||
-            (_editActionDetails.totalScale == _editorConfig.maxScale &&
-                totalScale >= _editActionDetails.totalScale))) {
+            (doubleEqual(
+                    _editActionDetails.totalScale, _editorConfig.maxScale) &&
+                doubleCompare(totalScale, _editActionDetails.totalScale) >=
+                    0))) {
       return;
     }
 

--- a/lib/src/editor/extended_image_editor_utils.dart
+++ b/lib/src/editor/extended_image_editor_utils.dart
@@ -285,13 +285,13 @@ class EditActionDetails {
   Rect computeBoundary(Rect result, Rect layoutRect) {
     if (_computeHorizontalBoundary) {
       //move right
-      if (result.left >= layoutRect.left) {
+      if (doubleCompare(result.left, layoutRect.left) >= 0) {
         result = Rect.fromLTWH(
             layoutRect.left, result.top, result.width, result.height);
       }
 
       ///move left
-      if (result.right <= layoutRect.right) {
+      if (doubleCompare(result.right, layoutRect.right) <= 0) {
         result = Rect.fromLTWH(layoutRect.right - result.width, result.top,
             result.width, result.height);
       }
@@ -299,23 +299,24 @@ class EditActionDetails {
 
     if (_computeVerticalBoundary) {
       //move down
-      if (result.bottom <= layoutRect.bottom) {
+      if (doubleCompare(result.bottom, layoutRect.bottom) <= 0) {
         result = Rect.fromLTWH(result.left, layoutRect.bottom - result.height,
             result.width, result.height);
       }
 
       //move up
-      if (result.top >= layoutRect.top) {
+      if (doubleCompare(result.top, layoutRect.top) >= 0) {
         result = Rect.fromLTWH(
             result.left, layoutRect.top, result.width, result.height);
       }
     }
 
     _computeHorizontalBoundary =
-        result.left <= layoutRect.left && result.right >= layoutRect.right;
+        doubleCompare(result.left, layoutRect.left) <= 0 &&
+            doubleCompare(result.right, layoutRect.right) >= 0;
 
-    _computeVerticalBoundary =
-        result.top <= layoutRect.top && result.bottom >= layoutRect.bottom;
+    _computeVerticalBoundary = doubleCompare(result.top, layoutRect.top) <= 0 &&
+        doubleCompare(result.bottom, layoutRect.bottom) >= 0;
     return result;
   }
 }
@@ -487,7 +488,24 @@ Rect rotateRect(Rect rect, Offset center, double angle) {
 }
 
 bool doubleEqual(double left, double right) {
-  return (left - right).abs() <= precisionErrorTolerance;
+  return doubleCompare(left, right) == 0;
+}
+
+/// Compare two double-precision values.
+/// Returns an integer that indicates whether [value] is less than, equal to, or greater than [other].
+///
+/// [value] less than [other] will return `-1`
+/// [value] equal to [other] will return `0`
+/// [value] greater than [other] will return `1`
+///
+/// If [value] or [other] is not finite (`NaN` or infinity), throws an [UnsupportedError].
+int doubleCompare(double value, double other,
+    {double precision = precisionErrorTolerance}) {
+  if (value.isNaN || other.isNaN)
+    throw UnsupportedError('Compared with Infinity or NaN');
+  double n = value - other;
+  if (n.abs() < precision) return 0;
+  return n < 0 ? -1 : 1;
 }
 
 enum InitCropRectType {

--- a/lib/src/editor/extended_image_editor_utils.dart
+++ b/lib/src/editor/extended_image_editor_utils.dart
@@ -3,6 +3,8 @@ import 'package:extended_image/src/extended_image_typedef.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../extended_image_utils.dart';
+
 class EditActionDetails {
   double _rotateRadian = 0.0;
   bool _flipX = false;
@@ -485,27 +487,6 @@ Rect rotateRect(Rect rect, Offset center, double angle) {
   var leftTop = rotateOffset(rect.topLeft, center, angle);
   var bottomRight = rotateOffset(rect.bottomRight, center, angle);
   return Rect.fromPoints(leftTop, bottomRight);
-}
-
-bool doubleEqual(double left, double right) {
-  return doubleCompare(left, right) == 0;
-}
-
-/// Compare two double-precision values.
-/// Returns an integer that indicates whether [value] is less than, equal to, or greater than [other].
-///
-/// [value] less than [other] will return `-1`
-/// [value] equal to [other] will return `0`
-/// [value] greater than [other] will return `1`
-///
-/// If [value] or [other] is not finite (`NaN` or infinity), throws an [UnsupportedError].
-int doubleCompare(double value, double other,
-    {double precision = precisionErrorTolerance}) {
-  if (value.isNaN || other.isNaN)
-    throw UnsupportedError('Compared with Infinity or NaN');
-  double n = value - other;
-  if (n.abs() < precision) return 0;
-  return n < 0 ? -1 : 1;
 }
 
 enum InitCropRectType {

--- a/lib/src/extended_image_utils.dart
+++ b/lib/src/extended_image_utils.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'extended_image.dart';
@@ -44,4 +45,30 @@ Type typeOf<T>() => T;
 
 double clampScale(double scale, double min, double max) {
   return scale.clamp(min, max);
+}
+
+/// Returns a value indicating whether two instances of Double represent the same value.
+///
+/// [value] equal to [other] will return `true`, otherwise, `false`.
+///
+/// If [value] or [other] is not finite (`NaN` or infinity), throws an [UnsupportedError].
+bool doubleEqual(double value, double other) {
+  return doubleCompare(value, other) == 0;
+}
+
+/// Compare two double-precision values.
+/// Returns an integer that indicates whether [value] is less than, equal to, or greater than [other].
+///
+/// [value] less than [other] will return `-1`
+/// [value] equal to [other] will return `0`
+/// [value] greater than [other] will return `1`
+///
+/// If [value] or [other] is not finite (`NaN` or infinity), throws an [UnsupportedError].
+int doubleCompare(double value, double other,
+    {double precision = precisionErrorTolerance}) {
+  if (value.isNaN || other.isNaN)
+    throw UnsupportedError('Compared with Infinity or NaN');
+  double n = value - other;
+  if (n.abs() < precision) return 0;
+  return n < 0 ? -1 : 1;
 }

--- a/lib/src/gesture/extended_image_gesture.dart
+++ b/lib/src/gesture/extended_image_gesture.dart
@@ -6,6 +6,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'extended_image_slide_page.dart';
+import '../editor/extended_image_editor_utils.dart';
 
 /// scale idea from https://github.com/flutter/flutter/blob/master/examples/layers/widgets/gestures.dart
 /// zoom image
@@ -138,7 +139,7 @@ class _ExtendedImageGestureState extends State<ExtendedImageGesture>
       bool updateGesture = false;
       if (!widget.extendedImageSlidePageState.isSliding) {
         if (offsetDelta.dx != 0 &&
-            offsetDelta.dx.abs() > offsetDelta.dy.abs()) {
+            doubleCompare(offsetDelta.dx.abs(), offsetDelta.dy.abs()) > 0) {
           if (_gestureDetails.computeHorizontalBoundary) {
             if (offsetDelta.dx > 0) {
               updateGesture = _gestureDetails.boundary.left;
@@ -150,7 +151,7 @@ class _ExtendedImageGestureState extends State<ExtendedImageGesture>
           }
         }
         if (offsetDelta.dy != 0 &&
-            offsetDelta.dy.abs() > offsetDelta.dx.abs()) {
+            doubleCompare(offsetDelta.dy.abs(), offsetDelta.dx.abs()) > 0) {
           if (_gestureDetails.computeVerticalBoundary) {
             if (offsetDelta.dy < 0) {
               updateGesture = _gestureDetails.boundary.bottom;
@@ -180,7 +181,7 @@ class _ExtendedImageGestureState extends State<ExtendedImageGesture>
 //        } else {}
 //      }
 
-      if (delta > minGesturePageDelta && updateGesture) {
+      if (doubleCompare(delta, minGesturePageDelta) > 0 && updateGesture) {
         _updateSlidePageStartingOffset ??= details.focalPoint;
         _updateSlidePageImageStartingOffset ??= _gestureDetails.offset;
         widget.extendedImageSlidePageState.slide(
@@ -203,10 +204,12 @@ class _ExtendedImageGestureState extends State<ExtendedImageGesture>
     //scale = roundAfter(scale, 3);
     //no more zoom
     if (details.scale != 1.0 &&
-        ((_gestureDetails.totalScale == _gestureConfig.animationMinScale &&
-                scale <= _gestureDetails.totalScale) ||
-            (_gestureDetails.totalScale == _gestureConfig.animationMaxScale &&
-                scale >= _gestureDetails.totalScale))) {
+        ((doubleEqual(_gestureDetails.totalScale,
+                    _gestureConfig.animationMinScale) &&
+                doubleCompare(scale, _gestureDetails.totalScale) <= 0) ||
+            (doubleEqual(_gestureDetails.totalScale,
+                    _gestureConfig.animationMaxScale) &&
+                doubleCompare(scale, _gestureDetails.totalScale) >= 0))) {
       return;
     }
 
@@ -237,7 +240,8 @@ class _ExtendedImageGestureState extends State<ExtendedImageGesture>
       return;
     }
     //animate back to maxScale if gesture exceeded the maxScale specified
-    if (_gestureDetails.totalScale > _gestureConfig.maxScale) {
+    if (doubleCompare(_gestureDetails.totalScale, _gestureConfig.maxScale) >
+        0) {
       final double velocity =
           (_gestureDetails.totalScale - _gestureConfig.maxScale) /
               _gestureConfig.maxScale;
@@ -248,7 +252,8 @@ class _ExtendedImageGestureState extends State<ExtendedImageGesture>
     }
 
     //animate back to minScale if gesture fell smaller than the minScale specified
-    if (_gestureDetails.totalScale < _gestureConfig.minScale) {
+    if (doubleCompare(_gestureDetails.totalScale, _gestureConfig.minScale) <
+        0) {
       final double velocity =
           (_gestureConfig.minScale - _gestureDetails.totalScale) /
               _gestureConfig.minScale;
@@ -263,7 +268,7 @@ class _ExtendedImageGestureState extends State<ExtendedImageGesture>
       final double magnitude = details.velocity.pixelsPerSecond.distance;
 
       // do a significant magnitude
-      if (magnitude >= minMagnitude) {
+      if (doubleCompare(magnitude, minMagnitude) >= 0) {
         final Offset direction = details.velocity.pixelsPerSecond /
             magnitude *
             _gestureConfig.inertialSpeed;

--- a/lib/src/gesture/extended_image_gesture_page_view.dart
+++ b/lib/src/gesture/extended_image_gesture_page_view.dart
@@ -343,7 +343,7 @@ class ExtendedImageGesturePageViewState
         final double magnitude = details.velocity.pixelsPerSecond.distance;
 
         // do a significant magnitude
-        if (magnitude >= minMagnitude) {
+        if (doubleCompare(magnitude, minMagnitude) >= 0) {
           Offset direction = details.velocity.pixelsPerSecond /
               magnitude *
               (extendedImageGestureState.imageGestureConfig.inertialSpeed);

--- a/lib/src/gesture/extended_image_gesture_utils.dart
+++ b/lib/src/gesture/extended_image_gesture_utils.dart
@@ -300,11 +300,11 @@ class GestureDetails {
       }
     }
 
-    _computeHorizontalBoundary =
-        result.left <= layoutRect.left && result.right >= layoutRect.right;
+    _computeHorizontalBoundary = result.left.ceil() <= layoutRect.left.ceil() &&
+        result.right.ceil() >= layoutRect.right.ceil();
 
-    _computeVerticalBoundary =
-        result.top <= layoutRect.top && result.bottom >= layoutRect.bottom;
+    _computeVerticalBoundary = result.top.ceil() <= layoutRect.top.ceil() &&
+        result.bottom.ceil() >= layoutRect.bottom.ceil();
 
     ///fix offset
     ///fix offset when it's not slide page

--- a/lib/src/gesture/extended_image_gesture_utils.dart
+++ b/lib/src/gesture/extended_image_gesture_utils.dart
@@ -3,6 +3,7 @@ import 'package:extended_image/src/extended_image_typedef.dart';
 import 'package:flutter/material.dart';
 
 import 'extended_image_slide_page.dart';
+import '../editor/extended_image_editor_utils.dart';
 
 ///
 ///  extended_image_gesture_utils.dart
@@ -13,10 +14,10 @@ import 'extended_image_slide_page.dart';
 
 ///whether gesture rect is out size
 bool outRect(Rect rect, Rect destinationRect) {
-  return destinationRect.top < rect.top ||
-      destinationRect.left < rect.left ||
-      destinationRect.right > rect.right ||
-      destinationRect.bottom > rect.bottom;
+  return doubleCompare(destinationRect.top, rect.top) < 0 ||
+      doubleCompare(destinationRect.left, rect.left) < 0 ||
+      doubleCompare(destinationRect.right, rect.right) > 0 ||
+      doubleCompare(destinationRect.bottom, rect.bottom) > 0;
 }
 
 class Boundary {
@@ -270,14 +271,14 @@ class GestureDetails {
 
     if (_computeHorizontalBoundary) {
       //move right
-      if (result.left >= layoutRect.left) {
+      if (doubleCompare(result.left, layoutRect.left) >= 0) {
         result = Rect.fromLTWH(
             layoutRect.left, result.top, result.width, result.height);
         _boundary.left = true;
       }
 
       ///move left
-      if (result.right <= layoutRect.right) {
+      if (doubleCompare(result.right, layoutRect.right) <= 0) {
         result = Rect.fromLTWH(layoutRect.right - result.width, result.top,
             result.width, result.height);
         _boundary.right = true;
@@ -286,25 +287,26 @@ class GestureDetails {
 
     if (_computeVerticalBoundary) {
       //move down
-      if (result.bottom <= layoutRect.bottom) {
+      if (doubleCompare(result.bottom, layoutRect.bottom) <= 0) {
         result = Rect.fromLTWH(result.left, layoutRect.bottom - result.height,
             result.width, result.height);
         _boundary.bottom = true;
       }
 
       //move up
-      if (result.top >= layoutRect.top) {
+      if (doubleCompare(result.top, layoutRect.top) >= 0) {
         result = Rect.fromLTWH(
             result.left, layoutRect.top, result.width, result.height);
         _boundary.top = true;
       }
     }
 
-    _computeHorizontalBoundary = result.left.ceil() <= layoutRect.left.ceil() &&
-        result.right.ceil() >= layoutRect.right.ceil();
+    _computeHorizontalBoundary =
+        doubleCompare(result.left, layoutRect.left) <= 0 &&
+            doubleCompare(result.right, layoutRect.right) >= 0;
 
-    _computeVerticalBoundary = result.top.ceil() <= layoutRect.top.ceil() &&
-        result.bottom.ceil() >= layoutRect.bottom.ceil();
+    _computeVerticalBoundary = doubleCompare(result.top, layoutRect.top) <= 0 &&
+        doubleCompare(result.bottom, layoutRect.bottom) >= 0;
 
     ///fix offset
     ///fix offset when it's not slide page
@@ -528,12 +530,13 @@ Color defaultSlidePageBackgroundHandler(
 bool defaultSlideEndHandler(
     {Offset offset, Size pageSize, SlideAxis pageGestureAxis}) {
   if (pageGestureAxis == SlideAxis.both) {
-    return offset.distance >
-        Offset(pageSize.width, pageSize.height).distance / 3.5;
+    return doubleCompare(offset.distance,
+            Offset(pageSize.width, pageSize.height).distance / 3.5) >
+        0;
   } else if (pageGestureAxis == SlideAxis.horizontal) {
-    return offset.dx.abs() > pageSize.width / 3.5;
+    return doubleCompare(offset.dx.abs(), pageSize.width / 3.5) > 0;
   } else if (pageGestureAxis == SlideAxis.vertical) {
-    return offset.dy.abs() > pageSize.height / 3.5;
+    return doubleCompare(offset.dy.abs(), pageSize.height / 3.5) > 0;
   }
   return true;
 }

--- a/lib/src/gesture/extended_image_gesture_utils.dart
+++ b/lib/src/gesture/extended_image_gesture_utils.dart
@@ -3,7 +3,7 @@ import 'package:extended_image/src/extended_image_typedef.dart';
 import 'package:flutter/material.dart';
 
 import 'extended_image_slide_page.dart';
-import '../editor/extended_image_editor_utils.dart';
+import '../extended_image_utils.dart';
 
 ///
 ///  extended_image_gesture_utils.dart

--- a/lib/src/gesture/extended_image_slide_page_handler.dart
+++ b/lib/src/gesture/extended_image_slide_page_handler.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'extended_image_gesture_utils.dart';
 import 'extended_image_slide_page.dart';
-import '../editor/extended_image_editor_utils.dart';
+import '../extended_image_utils.dart';
 
 ///
 ///  create by zmtzawqlp on 2019/6/14

--- a/lib/src/gesture/extended_image_slide_page_handler.dart
+++ b/lib/src/gesture/extended_image_slide_page_handler.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'extended_image_gesture_utils.dart';
 import 'extended_image_slide_page.dart';
+import '../editor/extended_image_editor_utils.dart';
 
 ///
 ///  create by zmtzawqlp on 2019/6/14
@@ -57,7 +58,7 @@ class ExtendedImageSlidePageHandlerState
 
       var delta = (details.focalPoint - _startingOffset).distance;
 
-      if (delta > minGesturePageDelta) {
+      if (doubleCompare(delta, minGesturePageDelta) > 0) {
         _updatePageGestureStartingOffset ??= details.focalPoint;
         widget.extendedImageSlidePageState.slide(
             details.focalPoint - _updatePageGestureStartingOffset,

--- a/lib/src/gesture/extended_image_slide_page_route.dart
+++ b/lib/src/gesture/extended_image_slide_page_route.dart
@@ -6,6 +6,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
+import '../editor/extended_image_editor_utils.dart';
+
 ///
 ///  create by zmtzawqlp on 2019/6/3
 ///
@@ -535,7 +537,7 @@ class _CupertinoBackGestureController<T> {
     // If the user releases the page before mid screen with sufficient velocity,
     // or after mid screen, we should animate the page out. Otherwise, the page
     // should be animated back in.
-    if (velocity.abs() >= _kMinFlingVelocity)
+    if (doubleCompare(velocity.abs(), _kMinFlingVelocity) >= 0)
       animateForward = velocity > 0 ? false : true;
     else
       animateForward = controller.value > 0.5 ? true : false;

--- a/lib/src/gesture/extended_image_slide_page_route.dart
+++ b/lib/src/gesture/extended_image_slide_page_route.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
-import '../editor/extended_image_editor_utils.dart';
+import '../extended_image_utils.dart';
 
 ///
 ///  create by zmtzawqlp on 2019/6/3


### PR DESCRIPTION
When the long image probabilistically scrolled to the bottom, the center value was calculated incorrectly, causing the image to roll back to the middle of the image.

e.g: 
700.33333333 >= 700.33333334 is false