### PR TITLE
Fix README / comment errors

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -149,7 +149,7 @@ ExtendedImageState 状态回调
 | imageStreamKey               | 图片流的唯一键                                                                                         | -    |
 | reLoadImage()                | 如果图片加载失败，你可以通过调用这个方法来重新加载图片                                                 | -    |
 | completedWidget              | 返回图片完成的 Widget，它包含手势以及裁剪                                                              | -    |
-| loadingProgress              | 返回网络图片加载进度 (ImageChunkEvent  )                                      | -    |
+| loadingProgress              | 返回网络图片加载进度 (ImageChunkEvent )                                                                | -    |
 
 ```dart
 abstract class ExtendedImageState {
@@ -248,24 +248,24 @@ ExtendedImage
 
 GestureConfig
 
-| 参数              | 描述                                                                                                     | 默认值                  |
-| ----------------- | -------------------------------------------------------------------------------------------------------- | ----------------------- |
-| minScale          | 缩放最小值                                                                                               | 0.8                     |
-| animationMinScale | 缩放动画最小值，当缩放结束时回到 minScale 值                                                             | minScale \* 0.8         |
-| maxScale          | 缩放最大值                                                                                               | 5.0                     |
-| animationMaxScale | 缩放动画最大值，当缩放结束时回到 maxScale 值                                                             | maxScale \* 1.2         |
-| speed             | 缩放拖拽速度，与用户操作成正比                                                                           | 1.0                     |
-| inertialSpeed     | 拖拽惯性速度，与惯性速度成正比                                                                           | 100                     |
-| cacheGesture      | 是否缓存手势状态，可用于 ExtendedImageGesturePageView 中保留状态，使用 clearGestureDetailsCache 方法清除 | false                   |
-| inPageView        | 是否使用 ExtendedImageGesturePageView 展示图片                                                           | false                   |
-| initialAlignment  | 当图片的初始化缩放大于 1.0 的时候，根据相对位置初始化图片                                                | InitialAlignment.center |
+| 参数              | 描述                                                                                                         | 默认值                  |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------- |
+| minScale          | 缩放最小值                                                                                                   | 0.8                     |
+| animationMinScale | 缩放动画最小值，当缩放结束时回到 minScale 值                                                                 | minScale \* 0.8         |
+| maxScale          | 缩放最大值                                                                                                   | 5.0                     |
+| animationMaxScale | 缩放动画最大值，当缩放结束时回到 maxScale 值                                                                 | maxScale \* 1.2         |
+| speed             | 缩放拖拽速度，与用户操作成正比                                                                               | 1.0                     |
+| inertialSpeed     | 拖拽惯性速度，与惯性速度成正比                                                                               | 100                     |
+| cacheGesture      | 是否缓存手势状态，可用于 ExtendedImageGesturePageView 中保留状态，**使用 clearGestureDetailsCache 方法清除** | false                   |
+| inPageView        | 是否使用 ExtendedImageGesturePageView 展示图片                                                               | false                   |
+| initialAlignment  | 当图片的初始化缩放大于 1.0 的时候，根据相对位置初始化图片                                                    | InitialAlignment.center |
 
 ```dart
 ExtendedImage.network(
   imageTestUrl,
   fit: BoxFit.contain,
   //enableLoadState: false,
-  mode: ExtendedImageMode.Gesture,
+  mode: ExtendedImageMode.gesture,
   initGestureConfigHandler: (state) {
     return GestureConfig(
         minScale: 0.9,
@@ -578,7 +578,7 @@ ExtendedImageGesturePageView.builder(
     Widget image = ExtendedImage.network(
       item,
       fit: BoxFit.contain,
-      mode: ExtendedImageMode.Gesture,
+      mode: ExtendedImageMode.gesture,
       gestureConfig: GestureConfig(
         inPageView: true, initialScale: 1.0,
         //you can cache gesture state even though page view page change.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ ExtendedImageState(LoadStateChanged call back)
 | imageStreamKey               | key of image                                                                                                                                  | -       |
 | reLoadImage()                | if image load failed,you can reload image by call it                                                                                          | -       |
 | completedWidget              | return completed widget include gesture or editor                                                                                             | -       |
-| loadingProgress              | return the loading progress for newwork image (ImageChunkEvent  )                                                                             | -       |
+| loadingProgress              | return the loading progress for newwork image (ImageChunkEvent )                                                                              | -       |
 
 ```dart
 abstract class ExtendedImageState {
@@ -242,28 +242,28 @@ ExtendedImage
 | ------------------------ | ------------------------------------------------------------------------------- | ------- |
 | mode                     | image mode (none,gestrue,editor)                                                | none    |
 | initGestureConfigHandler | init GestureConfig when image is ready，for example, base on image width/height | -       |
-| onDoubleTap              | call back of double tap under ExtendedImageMode.Gesture                         | -       |
+| onDoubleTap              | call back of double tap under ExtendedImageMode.gesture                         | -       |
 
 GestureConfig
 
-| parameter         | description                                                                                                                                                      | default                 |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| minScale          | min scale                                                                                                                                                        | 0.8                     |
-| animationMinScale | the min scale for zooming then animation back to minScale when scale end                                                                                         | minScale \_ 0.8         |
-| maxScale          | max scale                                                                                                                                                        | 5.0                     |
-| animationMaxScale | the max scale for zooming then animation back to maxScale when scale end                                                                                         | maxScale \_ 1.2         |
-| speed             | speed for zoom/pan                                                                                                                                               | 1.0                     |
-| inertialSpeed     | inertial speed for zoom/pan                                                                                                                                      | 100                     |
-| cacheGesture      | save Gesture state (for example in ExtendedImageGesturePageView, gesture state will not change when scroll back),remember clearGestureDetailsCache at right time | false                   |
-| inPageView        | whether in ExtendedImageGesturePageView                                                                                                                          | false                   |
-| initialAlignment  | init image rect with alignment when initialScale > 1.0                                                                                                           | InitialAlignment.center |
+| parameter         | description                                                                                                                                                          | default                 |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| minScale          | min scale                                                                                                                                                            | 0.8                     |
+| animationMinScale | the min scale for zooming then animation back to minScale when scale end                                                                                             | minScale \_ 0.8         |
+| maxScale          | max scale                                                                                                                                                            | 5.0                     |
+| animationMaxScale | the max scale for zooming then animation back to maxScale when scale end                                                                                             | maxScale \_ 1.2         |
+| speed             | speed for zoom/pan                                                                                                                                                   | 1.0                     |
+| inertialSpeed     | inertial speed for zoom/pan                                                                                                                                          | 100                     |
+| cacheGesture      | save Gesture state (for example in ExtendedImageGesturePageView, gesture state will not change when scroll back),**remember clearGestureDetailsCache at right time** | false                   |
+| inPageView        | whether in ExtendedImageGesturePageView                                                                                                                              | false                   |
+| initialAlignment  | init image rect with alignment when initialScale > 1.0                                                                                                               | InitialAlignment.center |
 
 ```dart
 ExtendedImage.network(
   imageTestUrl,
   fit: BoxFit.contain,
   //enableLoadState: false,
-  mode: ExtendedImageMode.Gesture,
+  mode: ExtendedImageMode.gesture,
   initGestureConfigHandler: (state) {
     return GestureConfig(
         minScale: 0.9,
@@ -570,7 +570,7 @@ ExtendedImageGesturePageView.builder(
     Widget image = ExtendedImage.network(
       item,
       fit: BoxFit.contain,
-      mode: ExtendedImageMode.Gesture,
+      mode: ExtendedImageMode.gesture,
       gestureConfig: GestureConfig(
         inPageView: true, initialScale: 1.0,
         //you can cache gesture state even though page view page change.

--- a/lib/src/extended_image.dart
+++ b/lib/src/extended_image.dart
@@ -455,7 +455,7 @@ class ExtendedImage extends StatefulWidget {
   ///init GestureConfig when image is ready.
   final InitGestureConfigHandler initGestureConfigHandler;
 
-  ///call back of double tap  under ExtendedImageMode.Gesture
+  ///call back of double tap  under ExtendedImageMode.gesture
   final DoubleTap onDoubleTap;
 
   ///whether cache in PaintingBinding.instance.imageCache


### PR DESCRIPTION
README 示例代码中的 `ExtendedImageMode.Gesture` 应该是过时代码了，最新代码的枚举值是小写开头了。

然后在我使用经历中，由于没有注意到清理手势缓存，造成了非常严重的内存泄漏。所以我把 `clearGestureDetailsCache` 相关的两段文字加粗了，因为这真的值得注意。