### PR TITLE
Fixed: No named parameter with the name 'animation'

### DIFF
--- a/lib/src/gesture/extended_image_slide_page_route.dart
+++ b/lib/src/gesture/extended_image_slide_page_route.dart
@@ -330,7 +330,8 @@ class TransparentCupertinoPageRoute<T> extends PageRoute<T> {
   ) {
     if (route.fullscreenDialog) {
       return CupertinoFullscreenDialogTransition(
-        animation: animation,
+        primaryRouteAnimation: animation,
+        secondaryRouteAnimation: secondaryAnimation,
         child: child,
       );
     } else {


### PR DESCRIPTION
Tried to convert my app to Flutter Web, came across  this error message. Solved it by adding the correct named arguments.

Flutter (Channel beta, v1.17.0-3.4.pre, on Mac OS X 10.15.4 19E287, locale en-GB)
    • Flutter version 1.17.0-3.4.pre at /Users/danielbreedeveld/Development/Tools/flutter
    • Framework revision e6b34c2b5c (2 days ago), 2020-05-02 11:39:18 -0700
    • Engine revision 540786dd51
    • Dart version 2.8.1

-------------------------

Compiler message:
../../Tools/flutter/.pub-cache/hosted/pub.dartlang.org/extended_image-0.7.2/lib/src/gesture/extended_image_slide_page_route.dart:333:9: Error: No named parameter with the name
'animation'.
        animation: animation,                                                                                      
        ^^^^^^^^^                                                                                                  
../../Tools/flutter/packages/flutter/lib/src/cupertino/route.dart:435:3: Context: Found this candidate, but the arguments don't match.
  CupertinoFullscreenDialogTransition({