### PR TITLE
Replace nullOk by maybeOf

### DIFF
--- a/lib/src/extended_image.dart
+++ b/lib/src/extended_image.dart
@@ -782,7 +782,7 @@ class _ExtendedImageState extends State<ExtendedImage>
   }
 
   void _updateInvertColors() {
-    _invertColors = MediaQuery.of(context, nullOk: true)?.invertColors ??
+    _invertColors = MediaQuery.maybeOf(context)?.invertColors ??
         SemanticsBinding.instance.accessibilityFeatures.invertColors;
   }
 


### PR DESCRIPTION
New flutter master has remove the `nullOk` in [this commit](https://github.com/flutter/flutter/commit/55289324c6d1db9071fb372f9f15f5ad5a064eeb) and it's causing error 
```
No named parameter with the name 'nullOk'
```
According [this feature](https://github.com/dart-lang/sdk/issues/43942), it needs to change to `maybeOf`
```
 _invertColors = MediaQuery.maybeOf(context)?.invertColors ??
        SemanticsBinding.instance.accessibilityFeatures.invertColors;
```