### PR TITLE
Remove `nullOk` in `MediaQuery.of`

### DIFF
--- a/lib/src/extended_image.dart
+++ b/lib/src/extended_image.dart
@@ -782,7 +782,7 @@ class _ExtendedImageState extends State<ExtendedImage>
   }
 
   void _updateInvertColors() {
-    _invertColors = MediaQuery.of(context, nullOk: true)?.invertColors ??
+    _invertColors = MediaQuery.maybeOf(context)?.invertColors ??
         SemanticsBinding.instance.accessibilityFeatures.invertColors;
   }
 


### PR DESCRIPTION
Flutter brought up a breaking change to eliminate nullOk parameters. See:

> https://github.com/flutter/flutter/pull/68736

This PR implements the proposed migration for this package.