### PR TITLE
:fire: Remove cacheMaxAge field and Upgrade dependencies.

### DIFF
--- a/lib/src/extended_image.dart
+++ b/lib/src/extended_image.dart
@@ -2,17 +2,18 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:extended_image/src/extended_image_border_painter.dart';
-import 'package:extended_image/src/gesture/extended_image_gesture.dart';
 import 'package:extended_image/src/extended_image_typedef.dart';
 import 'package:extended_image/src/extended_image_utils.dart';
+import 'package:extended_image/src/gesture/extended_image_gesture.dart';
 import 'package:extended_image/src/image/extended_raw_image.dart';
 import 'package:extended_image_library/extended_image_library.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Image;
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter/semantics.dart';
+
 import 'editor/extended_image_editor.dart';
 import 'gesture/extended_image_slide_page.dart';
 import 'gesture/extended_image_slide_page_handler.dart';
@@ -117,7 +118,6 @@ class ExtendedImage extends StatefulWidget {
     int? maxBytes,
     bool cacheRawData = false,
     String? imageCacheName,
-    Duration? cacheMaxAge,
   })  : assert(cacheWidth == null || cacheWidth > 0),
         assert(cacheHeight == null || cacheHeight > 0),
         image = ExtendedResizeImage.resizeIfNeeded(
@@ -134,7 +134,6 @@ class ExtendedImage extends StatefulWidget {
             printError: printError,
             cacheRawData: cacheRawData,
             imageCacheName: imageCacheName,
-            cacheMaxAge: cacheMaxAge,
           ),
           compressionRatio: compressionRatio,
           maxBytes: maxBytes,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   extended_image_library: ^3.1.0
   flutter:
     sdk: flutter
-  meta: ^1.1.8
+  meta: ^1.3.0
 


### PR DESCRIPTION
It's related to the [PR](https://github.com/fluttercandies/extended_image_library/pull/33)