### PR TITLE
add scale down  ability when horizontal  left or right draging animation is not end 

### DIFF
--- a/lib/src/gesture/extended_image_gesture.dart
+++ b/lib/src/gesture/extended_image_gesture.dart
@@ -117,6 +117,17 @@ class ExtendedImageGestureState extends State<ExtendedImageGesture>
     _gestureAnimation.dispose();
     super.dispose();
   }
+  
+  // public
+  void handleScaleStart(ScaleStartDetails details) {
+    _handleScaleStart(details);
+  }
+  void handleScaleUpdate(ScaleUpdateDetails details) {
+    _handleScaleUpdate(details);
+  }
+  void handleScaleEnd(ScaleEndDetails details) {
+    _handleScaleEnd(details);
+  }
 
   void _handleScaleStart(ScaleStartDetails details) {
     _gestureAnimation.stop();

--- a/lib/src/gesture/extended_image_gesture_page_view.dart
+++ b/lib/src/gesture/extended_image_gesture_page_view.dart
@@ -280,7 +280,17 @@ class ExtendedImageGesturePageViewState
         behavior: HitTestBehavior.opaque,
         child: result,
       );
+      
     }
+    // 目的是为了: 在PageView左右滑动时候, 能够增加上下滑动的体验
+    // 如果`widget.childrenDelegate`没有被`ExtendedImageSlidePage`包裹, 即开发者不使用下拉关闭功能, `extendedImageGestureState`为null, 不影响左右滑动
+    result = GestureDetector(
+      onScaleStart: extendedImageGestureState?.handleScaleStart,
+      onScaleUpdate: extendedImageGestureState?.handleScaleUpdate,
+      onScaleEnd: extendedImageGestureState?.handleScaleEnd,
+      child: result,
+    );
+    
     return result;
   }
 


### PR DESCRIPTION
when `ExtendedImageGesturePageView` is horizontal left or right drag is not end, user scale down the page is not effect,   this is a bad user expericce;
so add scale events wrap `PageView` widget, like wechat, make a better experience for the user.