### PR TITLE
Layout insets

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,26 @@ ExtendedImage
   );
 ```
 
+## Notch
+
+By setting layoutInsets, you can ensure the image is positioned outside of obstructing elements such as
+the phone notch or home indicator if displayed in full screen. This will still allow the image margin to
+show underneath the notch if zoomed in. 
+
+ExtendedImage
+
+| parameter        | description                                       | default         |
+| ---------------- | ------------------------------------------------- | --------------- |
+| layoutInsets     | Amount to inset from the edge during image layout | EdgeInsets.zero |
+
+```dart
+  ExtendedImage.network(
+    url,
+    fit: BoxFit.contain,
+    layoutInsets: MediaQuery.of(context).padding
+  );
+```
+
 see [paint image demo](https://github.com/fluttercandies/extended_image/blob/master/example/lib/pages/simple/paint_image_demo.dart)
 and [push to refresh header which is used in crop image demo](https://github.com/fluttercandies/extended_image/blob/master/example/lib/common/widget/push_to_refresh_header.dart)
 

--- a/lib/src/extended_image.dart
+++ b/lib/src/extended_image.dart
@@ -54,6 +54,7 @@ class ExtendedImage extends StatefulWidget {
     this.extendedImageGestureKey,
     this.isAntiAlias = false,
     this.handleLoadingProgress = false,
+    this.layoutInsets = EdgeInsets.zero,
   })  : assert(constraints == null || constraints.debugAssertIsValid()),
         constraints = (width != null || height != null)
             ? constraints?.tighten(width: width, height: height) ??
@@ -233,6 +234,7 @@ class ExtendedImage extends StatefulWidget {
     int? maxBytes,
     bool cacheRawData = false,
     String? imageCacheName,
+    this.layoutInsets = EdgeInsets.zero,
   })  : assert(cacheWidth == null || cacheWidth > 0),
         assert(cacheHeight == null || cacheHeight > 0),
         image = ExtendedResizeImage.resizeIfNeeded(
@@ -329,6 +331,7 @@ class ExtendedImage extends StatefulWidget {
     int? maxBytes,
     bool cacheRawData = false,
     String? imageCacheName,
+    this.layoutInsets = EdgeInsets.zero,
   })  :
         // FileImage is not supported on Flutter Web therefore neither this method.
         assert(
@@ -419,6 +422,7 @@ class ExtendedImage extends StatefulWidget {
     int? maxBytes,
     bool cacheRawData = false,
     String? imageCacheName,
+    this.layoutInsets = EdgeInsets.zero,
   })  : assert(cacheWidth == null || cacheWidth > 0),
         assert(cacheHeight == null || cacheHeight > 0),
         image = ExtendedResizeImage.resizeIfNeeded(
@@ -497,6 +501,7 @@ class ExtendedImage extends StatefulWidget {
     bool cacheRawData = false,
     String? imageCacheName,
     Duration? cacheMaxAge,
+    this.layoutInsets = EdgeInsets.zero,
   })  : assert(cacheWidth == null || cacheWidth > 0),
         assert(cacheHeight == null || cacheHeight > 0),
         image = ExtendedResizeImage.resizeIfNeeded(
@@ -794,6 +799,11 @@ class ExtendedImage extends StatefulWidget {
   /// Anti-aliasing alleviates the sawtooth artifact when the image is rotated.
   final bool isAntiAlias;
 
+  /// Insets to apply before laying out the image.
+  ///
+  /// The image will still be painted in the full area.
+  final EdgeInsets layoutInsets;
+
   @override
   _ExtendedImageState createState() => _ExtendedImageState();
   @override
@@ -822,6 +832,7 @@ class ExtendedImage extends StatefulWidget {
     properties.add(DiagnosticsProperty<bool>(
         'this.excludeFromSemantics', excludeFromSemantics));
     properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality));
+    properties.add(DiagnosticsProperty<EdgeInsets>('layoutInsets', layoutInsets));
   }
 }
 
@@ -1125,6 +1136,7 @@ class _ExtendedImageState extends State<ExtendedImage>
       filterQuality: widget.filterQuality,
       beforePaintImage: widget.beforePaintImage,
       afterPaintImage: widget.afterPaintImage,
+      layoutInsets: widget.layoutInsets,
     );
   }
 

--- a/lib/src/gesture/gesture.dart
+++ b/lib/src/gesture/gesture.dart
@@ -90,6 +90,7 @@ class ExtendedImageGestureState extends State<ExtendedImageGesture>
       beforePaintImage: widget.extendedImageState.imageWidget.beforePaintImage,
       afterPaintImage: widget.extendedImageState.imageWidget.afterPaintImage,
       gestureDetails: _gestureDetails,
+      layoutInsets: widget.extendedImageState.imageWidget.layoutInsets,
     );
 
     if (extendedImageSlidePageState != null) {

--- a/lib/src/image/painting.dart
+++ b/lib/src/image/painting.dart
@@ -26,10 +26,14 @@ void paintExtendedImage({
   GestureDetails? gestureDetails,
   EditActionDetails? editActionDetails,
   bool isAntiAlias = false,
+  EdgeInsets layoutInsets = EdgeInsets.zero
 }) {
   if (rect.isEmpty) {
     return;
   }
+
+  final Rect paintRect = rect;
+  rect = layoutInsets.deflateRect(rect);
 
   Size outputSize = rect.size;
   Size inputSize = Size(image.width.toDouble(), image.height.toDouble());
@@ -103,7 +107,7 @@ void paintExtendedImage({
 
     if (needClip) {
       canvas.save();
-      canvas.clipRect(rect);
+      canvas.clipRect(paintRect);
     }
   }
   bool hasEditAction = false;
@@ -131,7 +135,7 @@ void paintExtendedImage({
     if (needClip || hasEditAction) {
       canvas.save();
       if (needClip) {
-        canvas.clipRect(rect);
+        canvas.clipRect(paintRect);
       }
     }
 
@@ -178,7 +182,7 @@ void paintExtendedImage({
     canvas.save();
   }
   if (repeat != ImageRepeat.noRepeat) {
-    canvas.clipRect(rect);
+    canvas.clipRect(paintRect);
   }
   if (flipHorizontally) {
     final double dx = -(rect.left + rect.width / 2.0);

--- a/lib/src/image/raw_image.dart
+++ b/lib/src/image/raw_image.dart
@@ -41,6 +41,7 @@ class ExtendedRawImage extends LeafRenderObjectWidget {
     this.editActionDetails,
     this.isAntiAlias = false,
     this.debugImageLabel,
+    this.layoutInsets = EdgeInsets.zero,
   }) : super(key: key);
 
   @override
@@ -75,6 +76,7 @@ class ExtendedRawImage extends LeafRenderObjectWidget {
       gestureDetails: gestureDetails,
       editActionDetails: editActionDetails,
       isAntiAlias: isAntiAlias,
+      layoutInsets: layoutInsets,
     );
   }
 
@@ -227,6 +229,12 @@ class ExtendedRawImage extends LeafRenderObjectWidget {
 
   /// A string identifying the source of the image.
   final String? debugImageLabel;
+
+  /// Insets to apply before laying out the image.
+  ///
+  /// The image will still be painted in the full area.
+  final EdgeInsets layoutInsets;
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
@@ -250,6 +258,7 @@ class ExtendedRawImage extends LeafRenderObjectWidget {
         value: matchTextDirection, ifTrue: 'match text direction'));
     properties.add(DiagnosticsProperty<bool>('invertColors', invertColors));
     properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality));
+    properties.add(DiagnosticsProperty<EdgeInsets>('layoutInsets', layoutInsets));
   }
 
   @override
@@ -282,7 +291,8 @@ class ExtendedRawImage extends LeafRenderObjectWidget {
       ..sourceRect = sourceRect
       ..gestureDetails = gestureDetails
       ..editActionDetails = editActionDetails
-      ..isAntiAlias = isAntiAlias;
+      ..isAntiAlias = isAntiAlias
+      ..layoutInsets = layoutInsets;
   }
 
   @override

--- a/lib/src/image/render_image.dart
+++ b/lib/src/image/render_image.dart
@@ -37,6 +37,8 @@ class ExtendedRenderImage extends RenderBox {
     BeforePaintImage? beforePaintImage,
     GestureDetails? gestureDetails,
     EditActionDetails? editActionDetails,
+    EdgeInsets layoutInsets = EdgeInsets.zero,
+  
   })  : _image = image,
         _width = width,
         _height = height,
@@ -57,8 +59,19 @@ class ExtendedRenderImage extends RenderBox {
         _beforePaintImage = beforePaintImage,
         _afterPaintImage = afterPaintImage,
         _gestureDetails = gestureDetails,
-        _editActionDetails = editActionDetails {
+        _editActionDetails = editActionDetails,
+        _layoutInsets = layoutInsets {
     _updateColorFilter();
+  }
+
+  EdgeInsets _layoutInsets;
+  EdgeInsets get layoutInsets => _layoutInsets;
+  set layoutInsets(EdgeInsets value) {
+    if (value == _layoutInsets) {
+      return;
+    }
+    _layoutInsets = value;
+    markNeedsPaint();
   }
 
   EditActionDetails? _editActionDetails;
@@ -509,6 +522,7 @@ class ExtendedRenderImage extends RenderBox {
       afterPaintImage: afterPaintImage,
       gestureDetails: gestureDetails,
       editActionDetails: editActionDetails,
+      layoutInsets: layoutInsets,
     );
   }
 


### PR DESCRIPTION
You can provide `layoutInsets` on the image, this could be use to position outside of the notch, home indicator. But you can still zoom, and it will paint underneath those edges. It will let you scroll to the edge of the image, and you could drag the image outside of the notch to see all the details. 

Fixes #417

Please note, to get `Hero` to work without any jumping, you might need to do something like the following, in case you have different `layoutInsets` on both widgets. 

```dart
heroBuilderForSlidingPage: (Widget result) {
  return Hero(
    tag: _tag,
    child: result,
    flightShuttleBuilder: (ctx, animation, direction, from, to) => AnimatedBuilder(
      animation: animation,
      builder: (ctx, child) => Padding(
        padding: layoutInsets * animation.value,
        child: child
      ),
      child: from.widget
    )
  );
}
```

I don't think the above could be automatically done.