### PR TITLE
Fix issue with onDragEnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.1
+
+* Fix issue with onDragEnd
+
 ## 8.1.0
 
 * Migrate to 3.13.0 

--- a/lib/src/gesture/page_view/gesture_page_view.dart
+++ b/lib/src/gesture/page_view/gesture_page_view.dart
@@ -423,10 +423,10 @@ class ExtendedImageGesturePageViewState
     // _drag might be null if the drag activity ended and called _disposeDrag.
     assert(_hold == null || _drag == null);
     if (!widget.canScrollPage(extendedImageGestureState?.gestureDetails)) {
-      _drag!.end(DragEndDetails(primaryVelocity: 0.0));
+      _drag?.end(DragEndDetails(primaryVelocity: 0.0));
       return;
     }
-    _drag!.end(details);
+    _drag?.end(details);
     assert(_drag == null);
     // return;
     // DragEndDetails temp = details;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: extended_image
 description: Official extension image, support placeholder(loading)/ failed state, cache network, zoom/pan, photo view, slide out page, editor(crop,rotate,flip), painting etc.
-version: 8.1.0
+version: 8.1.1
 homepage: https://github.com/fluttercandies/extended_image
 
 environment:


### PR DESCRIPTION
Fix https://github.com/fluttercandies/extended_image/issues/601

This is a working solution to get rid of the crash. Checked using a forked version of the library with a modified line
<img width="843" alt="Снимок экрана 2023-09-06 в 14 15 43" src="https://github.com/fluttercandies/extended_image/assets/120365747/35c55c99-ec94-4cd3-ab5d-c735647f9d8b">

```
UnhandledFlutterException: Null check operator used on a null value
       at extended_image.src.gesture.page_view.gesture_page_view.dart.ExtendedImageGesturePageViewState.onDragEnd(gesture_page_view.dart:426)
       at extended_image.src.gesture_detector.drag.dart.ExtendedDragGestureRecognizer._checkEnd.<fn>(drag.dart:623)
       at flutter.src.gestures.recognizer.dart.GestureRecognizer.invokeCallback(recognizer.dart:253)
       at extended_image.src.gesture_detector.drag.dart.ExtendedDragGestureRecognizer._checkEnd(drag.dart:623)
       at extended_image.src.gesture_detector.drag.dart.ExtendedDragGestureRecognizer.didStopTrackingLastPointer(drag.dart:526)
       at flutter.src.gestures.recognizer.dart.OneSequenceGestureRecognizer.stopTrackingPointer(recognizer.dart:446)
       at extended_image.src.gesture_detector.drag.dart.ExtendedDragGestureRecognizer._giveUpPointer(drag.dart:535)
       at extended_image.src.gesture_detector.drag.dart.ExtendedDragGestureRecognizer.handleEvent(drag.dart:449)
       at flutter.src.gestures.pointer_router.dart.PointerRouter._dispatch(pointer_router.dart:98)
       at flutter.src.gestures.pointer_router.dart.PointerRouter._dispatchEventToRoutes.<fn>(pointer_router.dart:143)
       at collection-patch.compact_hash.dart._LinkedHashMapMixin.forEach(compact_hash.dart:625)
       at flutter.src.gestures.pointer_router.dart.PointerRouter._dispatchEventToRoutes(pointer_router.dart:141)
       at flutter.src.gestures.pointer_router.dart.PointerRouter.route(pointer_router.dart:127)
       at flutter.src.gestures.binding.dart.GestureBinding.handleEvent(binding.dart:460)
       at flutter.src.gestures.binding.dart.GestureBinding.dispatchEvent(binding.dart:440)
       at flutter.src.rendering.binding.dart.RendererBinding.dispatchEvent(binding.dart:336)
       at flutter.src.gestures.binding.dart.GestureBinding._handlePointerEventImmediately(binding.dart:395)
       at flutter.src.gestures.binding.dart.GestureBinding.handlePointerEvent(binding.dart:357)
       at flutter.src.gestures.binding.dart.GestureBinding._flushPointerEventQueue(binding.dart:314)
       at flutter.src.gestures.binding.dart.GestureBinding._handlePointerDataPacket(binding.dart:295)
       at async.zone.dart._rootRunUnary(zone.dart:1414)
       at async.zone.dart._CustomZone.runUnary(zone.dart:1307)
       at async.zone.dart._CustomZone.runUnaryGuarded(zone.dart:1216)
       at ui.hooks.dart._invoke1(hooks.dart:166)
       at ui.platform_dispatcher.dart.PlatformDispatcher._dispatchPointerDataPacket(platform_dispatcher.dart:361)
       at ui.hooks.dart._dispatchPointerDataPacket(hooks.dart:91)
       ```
