### PR TITLE
fix: employ a later version of the API

### DIFF
--- a/example/lib/common/widget/common_widget.dart
+++ b/example/lib/common/widget/common_widget.dart
@@ -17,7 +17,7 @@ class FlatButtonWithIcon extends TextButton {
           focusNode: focusNode,
           style: textColor != null
               ? ButtonStyle(
-                  textStyle: WidgetStateProperty.all<TextStyle>(
+                  textStyle: MaterialStateProperty.all<TextStyle>(
                   TextStyle(color: textColor),
                 ))
               : null,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: '>=2.18.0 <4.0.0'
-  flutter: '>=3.22.0'
+  flutter: '>=3.16.0'
 dependencies:
   extended_sliver: any
   ff_annotation_route_library: any

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: '>=2.18.0 <4.0.0'
-  flutter: '>=3.16.0'
+  flutter: '>=3.22.0'
 dependencies:
   extended_sliver: any
   ff_annotation_route_library: any


### PR DESCRIPTION
WidgetStateProperty is used in example/lib/common/widget/common_widget.dart, if it is lower than 3.22.0, an error will be reported