### PR TITLE
Added cropAspectRatioRange support;

### DIFF
--- a/lib/src/editor/crop_layer.dart
+++ b/lib/src/editor/crop_layer.dart
@@ -388,7 +388,26 @@ class ExtendedImageCropLayerState extends State<ExtendedImageCropLayer>
   Rect _handleAspectRatio(double gWidth, _MoveType moveType, Rect result,
       Rect? layerDestinationRect, Offset delta) {
     final double? aspectRatio = widget.editActionDetails.cropAspectRatio;
-    // do with aspect ratio
+    final List<double>? aspectRatioRange =
+        widget.editActionDetails.cropAspectRatioRange;
+
+    /// If the aspect ratio range is set, calculate whether the current aspect ratio is within the range.
+    if (aspectRatioRange != null && aspectRatioRange.length == 2) {
+      final double minRatio = aspectRatioRange[0];
+      final double maxRatio = aspectRatioRange[1];
+      final double currentRatio = result.width / result.height;
+
+      /// If the current ratio is beyond the range, adjust to the nearest valid ratio.
+      if (currentRatio < minRatio) {
+        final double newWidth = result.height * minRatio;
+        return _adjustRectSize(result, newWidth, result.height, moveType);
+      } else if (currentRatio > maxRatio) {
+        final double newWidth = result.height * maxRatio;
+        return _adjustRectSize(result, newWidth, result.height, moveType);
+      }
+      return result;
+    }
+
     if (aspectRatio != null) {
       final double minD = gWidth * 2;
       switch (moveType) {
@@ -450,6 +469,40 @@ class ExtendedImageCropLayerState extends State<ExtendedImageCropLayer>
       }
     }
     return result;
+  }
+
+  /// Adjust the size of the rectangle based on the move type
+  Rect _adjustRectSize(
+      Rect rect, double width, double height, _MoveType moveType) {
+    double left = rect.left;
+    double top = rect.top;
+
+    switch (moveType) {
+      case _MoveType.topLeft:
+        left = rect.right - width;
+        top = rect.bottom - height;
+        break;
+      case _MoveType.topRight:
+        top = rect.bottom - height;
+        break;
+      case _MoveType.bottomLeft:
+        left = rect.right - width;
+        break;
+      case _MoveType.bottomRight:
+        break;
+      case _MoveType.left:
+        left = rect.right - width;
+        break;
+      case _MoveType.right:
+        break;
+      case _MoveType.top:
+        top = rect.bottom - height;
+        break;
+      case _MoveType.bottom:
+        break;
+    }
+
+    return Rect.fromLTWH(left, top, width, height);
   }
 
   ///horizontal

--- a/lib/src/editor/edit_action_details.dart
+++ b/lib/src/editor/edit_action_details.dart
@@ -26,6 +26,8 @@ class EditActionDetails {
 
   double? _cropAspectRatio;
 
+  List<double>? _cropAspectRatioRange;
+
   /// the original aspect ratio
   double? get originalCropAspectRatio => _cropAspectRatio;
 
@@ -40,6 +42,14 @@ class EditActionDetails {
   set cropAspectRatio(double? value) {
     if (_cropAspectRatio != value) {
       _cropAspectRatio = value;
+    }
+  }
+
+  List<double>? get cropAspectRatioRange => _cropAspectRatioRange;
+
+  set cropAspectRatioRange(List<double>? value) {
+    if (value != null && value.length == 2) {
+      _cropAspectRatioRange = value;
     }
   }
 

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -149,6 +149,11 @@ class ExtendedImageEditorState extends State<ExtendedImageEditor>
       _editActionDetails!.cropAspectRatio = _editorConfig!.cropAspectRatio;
     }
 
+    if (_editActionDetails!.cropAspectRatioRange == null) {
+      _editActionDetails!.cropAspectRatioRange =
+          _editorConfig!.cropAspectRatioRange;
+    }
+
     if (oldConfig != null &&
         oldConfig.cropAspectRatio != config.cropAspectRatio) {
       updateCropAspectRatio(config.cropAspectRatio);

--- a/lib/src/editor/editor_config.dart
+++ b/lib/src/editor/editor_config.dart
@@ -28,6 +28,7 @@ class EditorConfig {
     this.hitTestSize = 20.0,
     this.animationDuration = const Duration(milliseconds: 200),
     this.tickerDuration = const Duration(milliseconds: 400),
+    this.cropAspectRatioRange,
     this.cropAspectRatio = CropAspectRatios.custom,
     this.initialCropAspectRatio = CropAspectRatios.custom,
     this.initCropRectType = InitCropRectType.imageRect,
@@ -95,6 +96,11 @@ class EditorConfig {
   /// By default, it's set to custom, allowing freeform cropping unless specified otherwise.
   final double? cropAspectRatio;
 
+  /// Range of aspect ratios for the crop rect.
+  /// This is a list of possible aspect ratios the crop rect can have.
+  /// By default, it's an empty list, meaning no specific range is set.
+  final List<double>? cropAspectRatioRange;
+
   /// Initial aspect ratio of the crop rect. This only affects the initial state of the crop rect,
   /// giving users the option to start with a pre-defined aspect ratio.
   final double? initialCropAspectRatio;
@@ -132,6 +138,7 @@ class EditorConfig {
     Duration? animationDuration,
     Duration? tickerDuration,
     double? cropAspectRatio,
+    List<double>? cropAspectRatioRange,
     double? initialCropAspectRatio,
     InitCropRectType? initCropRectType,
     EditorCropLayerPainter? cropLayerPainter,
@@ -154,6 +161,7 @@ class EditorConfig {
       animationDuration: animationDuration ?? this.animationDuration,
       tickerDuration: tickerDuration ?? this.tickerDuration,
       cropAspectRatio: cropAspectRatio ?? this.cropAspectRatio,
+      cropAspectRatioRange: cropAspectRatioRange ?? this.cropAspectRatioRange,
       initialCropAspectRatio:
           initialCropAspectRatio ?? this.initialCropAspectRatio,
       initCropRectType: initCropRectType ?? this.initCropRectType,
@@ -185,6 +193,7 @@ class EditorConfig {
         other.animationDuration == animationDuration &&
         other.tickerDuration == tickerDuration &&
         other.cropAspectRatio == cropAspectRatio &&
+        other.cropAspectRatioRange == cropAspectRatioRange &&
         other.initialCropAspectRatio == initialCropAspectRatio &&
         other.initCropRectType == initCropRectType &&
         other.cropLayerPainter == cropLayerPainter &&
@@ -210,6 +219,7 @@ class EditorConfig {
       animationDuration,
       tickerDuration,
       cropAspectRatio,
+      cropAspectRatioRange,
       initialCropAspectRatio,
       initCropRectType,
       cropLayerPainter,


### PR DESCRIPTION
小众的需求，支持配置一个裁剪比例的最小值和最大值，实现可以在这个范围内进行裁剪。因为我们后端说图片不要太长也不要太扁，在一个合理的范围内就行。

代码没有好好写，只是满足我们的需求，提个 PR 是为了方便如果有兄弟们需要这个功能，可以参考一下怎么实现。我也很期待官方能直接支持一下，谢谢啦。

Niche demand. Support configuring a minimum and maximum value for the cropping ratio, so that cropping can be performed within this range. Because our back-end said that the picture should not be too long or too flat. It should be within a reasonable range.

The code is not written well. It only meets our needs. Submitting a pull request is to facilitate. If there are brothers who need this function, they can refer to how it is implemented. I also very much hope that the official can directly support it. Thank you.

![image](https://github.com/user-attachments/assets/9c27ad12-27b6-4a6f-a7f0-fef2527e0a39)

https://github.com/user-attachments/assets/d40da0a6-db4c-494d-9602-e896686d5e96
