### PR TITLE
Add custom widget gesture support

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,28 @@ ExtendedImage.network(
 )
 ```
 
+### custom widget gesture
+
+Use `ExtendedImageGestureWidget` when the content should stay as a widget tree,
+for example an SVG widget, chart, or video, while still using extended_image
+zoom, pan, double-tap, page-view, and slide-page behavior.
+
+```dart
+ExtendedImageGestureWidget(
+  childSize: const Size(300, 180),
+  fit: BoxFit.contain,
+  child: SvgPicture.string(svgSource),
+  initGestureConfigHandler: (state) {
+    return GestureConfig(
+      minScale: 0.8,
+      maxScale: 5.0,
+      initialScale: 1.0,
+      inPageView: false,
+    );
+  },
+)
+```
+
 ### double tap animation
 
 ```dart

--- a/example/lib/pages/simple/zoom_image_demo.dart
+++ b/example/lib/pages/simple/zoom_image_demo.dart
@@ -16,6 +16,8 @@ class ZoomImageDemo extends StatelessWidget {
   // you can handle gesture detail by yourself with key
   final GlobalKey<ExtendedImageGestureState> gestureKey =
       GlobalKey<ExtendedImageGestureState>();
+  final GlobalKey<ExtendedImageGestureState> customGestureKey =
+      GlobalKey<ExtendedImageGestureState>();
   @override
   Widget build(BuildContext context) {
     return Material(
@@ -28,6 +30,7 @@ class ZoomImageDemo extends StatelessWidget {
                 icon: const Icon(Icons.restore),
                 onPressed: () {
                   gestureKey.currentState!.reset();
+                  customGestureKey.currentState!.reset();
                   //you can also change zoom manual
                   //gestureKey.currentState.gestureDetails=GestureDetails();
                 },
@@ -55,6 +58,52 @@ class ZoomImageDemo extends StatelessWidget {
                   gestureDetailsIsChanged: (GestureDetails? details) {
                     //print(details?.totalScale);
                   },
+                );
+              },
+            ),
+          ),
+          const Divider(height: 1),
+          SizedBox(
+            height: 220,
+            child: ExtendedImageGestureWidget(
+              extendedImageGestureKey: customGestureKey,
+              childSize: const Size(240, 160),
+              fit: BoxFit.contain,
+              child: const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Color(0xFFEDE7F6),
+                  border: Border.fromBorderSide(
+                    BorderSide(color: Colors.deepPurple),
+                  ),
+                  borderRadius: BorderRadius.all(Radius.circular(16)),
+                ),
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Icon(Icons.widgets, size: 48, color: Colors.deepPurple),
+                      SizedBox(height: 8),
+                      Text(
+                        'Custom Widget',
+                        style: TextStyle(
+                          color: Colors.deepPurple,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text('Zoom and pan without image bytes'),
+                    ],
+                  ),
+                ),
+              ),
+              initGestureConfigHandler: (ExtendedImageState state) {
+                return GestureConfig(
+                  minScale: 0.9,
+                  animationMinScale: 0.7,
+                  maxScale: 4.0,
+                  animationMaxScale: 4.5,
+                  initialScale: 1.0,
+                  initialAlignment: InitialAlignment.center,
+                  reverseMousePointerScrollDirection: true,
                 );
               },
             ),

--- a/lib/extended_image.dart
+++ b/lib/extended_image.dart
@@ -11,6 +11,7 @@ export 'src/editor/editor_crop_layer_painter.dart';
 export 'src/editor/editor_utils.dart';
 export 'src/extended_image.dart';
 export 'src/gesture/gesture.dart';
+export 'src/gesture/gesture_widget.dart';
 export 'src/gesture/page_view/gesture_page_view.dart';
 export 'src/gesture/slide_page.dart';
 export 'src/gesture/slide_page_handler.dart';

--- a/lib/src/gesture/gesture.dart
+++ b/lib/src/gesture/gesture.dart
@@ -536,6 +536,7 @@ class ExtendedImageGestureState extends State<ExtendedImageGesture>
     double? imageWidth,
     double? imageHeight,
     BoxFit? imageFit,
+    Alignment alignment = Alignment.center,
     Rect? rect,
     bool copy = false,
   }) {
@@ -545,6 +546,7 @@ class ExtendedImageGestureState extends State<ExtendedImageGesture>
         imageWidth: imageWidth,
         imageHeight: imageHeight,
         imageFit: imageFit,
+        alignment: alignment,
         rect: rect,
         copy: copy,
       ),
@@ -579,6 +581,7 @@ class GestureWidgetDelegateFromState extends SingleChildLayoutDelegate {
     this.imageFit,
     this.imageHeight,
     this.imageWidth,
+    this.alignment = Alignment.center,
     this.rect,
     this.copy = false,
   });
@@ -587,6 +590,7 @@ class GestureWidgetDelegateFromState extends SingleChildLayoutDelegate {
   final double? imageWidth;
   final double? imageHeight;
   final BoxFit? imageFit;
+  final Alignment alignment;
   final Rect? rect;
   final bool copy;
 
@@ -599,6 +603,7 @@ class GestureWidgetDelegateFromState extends SingleChildLayoutDelegate {
       width: imageWidth,
       height: imageHeight,
       fit: imageFit,
+      alignment: alignment,
       copy: copy,
     );
   }
@@ -614,6 +619,7 @@ class GestureWidgetDelegateFromState extends SingleChildLayoutDelegate {
         imageWidth != oldDelegate.imageWidth ||
         imageHeight != oldDelegate.imageHeight ||
         imageFit != oldDelegate.imageFit ||
+        alignment != oldDelegate.alignment ||
         rect != oldDelegate.rect ||
         copy != oldDelegate.copy;
   }
@@ -639,6 +645,7 @@ class GestureWidgetDelegateFromState extends SingleChildLayoutDelegate {
     double? width,
     double? height,
     BoxFit? fit,
+    Alignment alignment = Alignment.center,
     bool copy = false,
   }) {
     final GestureDetails? gestureDetails = state.gestureDetails;
@@ -658,6 +665,7 @@ class GestureWidgetDelegateFromState extends SingleChildLayoutDelegate {
                 .toDouble(),
       ),
       fit: fit ?? state.widget.extendedImageState.imageWidget.fit,
+      alignment: alignment,
     );
 
     if (gestureDetails != null) {

--- a/lib/src/gesture/gesture_widget.dart
+++ b/lib/src/gesture/gesture_widget.dart
@@ -1,0 +1,310 @@
+import 'dart:typed_data';
+
+import 'package:extended_image/src/extended_image.dart';
+import 'package:extended_image/src/gesture/gesture.dart';
+import 'package:extended_image/src/gesture/slide_page.dart';
+import 'package:extended_image/src/typedef.dart';
+import 'package:extended_image/src/utils.dart';
+import 'package:flutter/material.dart' hide Image;
+
+/// A widget that applies [ExtendedImageGesture] zoom, pan, page-view, and
+/// slide-page behavior to an arbitrary child widget.
+///
+/// This is useful for vector images, SVG widgets, video, charts, or other
+/// widget trees that should keep rendering as widgets instead of being decoded
+/// into a [dart:ui.Image]. [childSize] is the logical size of [child] before it
+/// is fitted into this widget's layout bounds.
+class ExtendedImageGestureWidget extends StatefulWidget {
+  ExtendedImageGestureWidget({
+    Key? key,
+    required this.child,
+    required this.childSize,
+    this.width,
+    this.height,
+    BoxConstraints? constraints,
+    this.fit,
+    this.alignment = Alignment.center,
+    this.semanticLabel,
+    this.excludeFromSemantics = false,
+    this.onDoubleTap,
+    this.initGestureConfigHandler,
+    this.enableSlideOutPage = false,
+    this.heroBuilderForSlidingPage,
+    this.extendedImageGestureKey,
+    this.canScaleImage,
+    this.gestureCacheKey,
+  }) : assert(childSize.width > 0.0),
+       assert(childSize.height > 0.0),
+       assert(constraints == null || constraints.debugAssertIsValid()),
+       constraints = (width != null || height != null)
+           ? constraints?.tighten(width: width, height: height) ??
+                 BoxConstraints.tightFor(width: width, height: height)
+           : constraints,
+       super(key: key);
+
+  /// The widget rendered through the gesture layout machinery.
+  final Widget child;
+
+  /// Logical size of [child] before [fit] and gesture transforms are applied.
+  final Size childSize;
+
+  /// If non-null, require the gesture viewport to have this width.
+  final double? width;
+
+  /// If non-null, require the gesture viewport to have this height.
+  final double? height;
+
+  /// Additional layout constraints for the gesture viewport.
+  final BoxConstraints? constraints;
+
+  /// How to inscribe [childSize] into the gesture viewport before zooming.
+  final BoxFit? fit;
+
+  /// How to align [child] inside the gesture viewport before zooming.
+  final Alignment alignment;
+
+  /// A semantic description of the custom child.
+  final String? semanticLabel;
+
+  /// Whether to exclude this widget from semantics.
+  final bool excludeFromSemantics;
+
+  /// Callback for double tap under gesture mode.
+  final DoubleTap? onDoubleTap;
+
+  /// Init [GestureConfig] for this custom child.
+  final InitGestureConfigHandler? initGestureConfigHandler;
+
+  /// Whether to enable slide out page.
+  ///
+  /// This should be true only when this widget is inside [ExtendedImageSlidePage].
+  final bool enableSlideOutPage;
+
+  /// Build Hero only for sliding page.
+  final HeroBuilderForSlidingPage? heroBuilderForSlidingPage;
+
+  /// Key of the internal [ExtendedImageGesture].
+  final Key? extendedImageGestureKey;
+
+  /// Whether the child should scale for the current gesture details.
+  final CanScaleImage? canScaleImage;
+
+  /// Cache key used when [GestureConfig.cacheGesture] is true.
+  ///
+  /// If omitted, this state's identity is used to avoid sharing gesture details
+  /// between unrelated custom gesture widgets.
+  final Object? gestureCacheKey;
+
+  @override
+  _ExtendedImageGestureWidgetState createState() =>
+      _ExtendedImageGestureWidgetState();
+}
+
+class _ExtendedImageGestureWidgetState extends State<ExtendedImageGestureWidget>
+    with ExtendedImageState {
+  static final Uint8List _transparentImageBytes = Uint8List.fromList(<int>[
+    0x89,
+    0x50,
+    0x4E,
+    0x47,
+    0x0D,
+    0x0A,
+    0x1A,
+    0x0A,
+    0x00,
+    0x00,
+    0x00,
+    0x0D,
+    0x49,
+    0x48,
+    0x44,
+    0x52,
+    0x00,
+    0x00,
+    0x00,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    0x01,
+    0x08,
+    0x06,
+    0x00,
+    0x00,
+    0x00,
+    0x1F,
+    0x15,
+    0xC4,
+    0x89,
+    0x00,
+    0x00,
+    0x00,
+    0x0A,
+    0x49,
+    0x44,
+    0x41,
+    0x54,
+    0x78,
+    0x9C,
+    0x63,
+    0x00,
+    0x01,
+    0x00,
+    0x00,
+    0x05,
+    0x00,
+    0x01,
+    0x0D,
+    0x0A,
+    0x2D,
+    0xB4,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x49,
+    0x45,
+    0x4E,
+    0x44,
+    0xAE,
+    0x42,
+    0x60,
+    0x82,
+  ]);
+  static final ImageProvider _transparentImageProvider = MemoryImage(
+    _transparentImageBytes,
+  );
+
+  late ExtendedImage _imageWidget;
+  ExtendedImageSlidePageState? _slidePageState;
+
+  @override
+  Widget get completedWidget => _buildGestureWidget();
+
+  @override
+  ImageInfo? get extendedImageInfo => null;
+
+  @override
+  LoadState get extendedImageLoadState => LoadState.completed;
+
+  @override
+  int? get frameNumber => 0;
+
+  @override
+  ImageProvider get imageProvider => _transparentImageProvider;
+
+  @override
+  Object? get imageStreamKey => widget.gestureCacheKey ?? this;
+
+  @override
+  ExtendedImage get imageWidget => _imageWidget;
+
+  @override
+  bool get invertColors => false;
+
+  @override
+  Object? get lastException => null;
+
+  @override
+  StackTrace? get lastStack => null;
+
+  @override
+  ImageChunkEvent? get loadingProgress => null;
+
+  @override
+  ExtendedImageSlidePageState? get slidePageState => _slidePageState;
+
+  @override
+  bool get wasSynchronouslyLoaded => true;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget current = _buildGestureWidget();
+
+    if (widget.constraints != null) {
+      current = ConstrainedBox(
+        constraints: widget.constraints!,
+        child: current,
+      );
+    }
+
+    if (widget.excludeFromSemantics) {
+      return current;
+    }
+
+    return Semantics(
+      container: widget.semanticLabel != null,
+      image: true,
+      label: widget.semanticLabel ?? '',
+      child: current,
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    _updateSlidePageState();
+    super.didChangeDependencies();
+  }
+
+  @override
+  void didUpdateWidget(covariant ExtendedImageGestureWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _imageWidget = _buildImageWidget();
+    if (widget.enableSlideOutPage != oldWidget.enableSlideOutPage) {
+      _updateSlidePageState();
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    returnLoadStateChangedWidget = false;
+    _imageWidget = _buildImageWidget();
+  }
+
+  @override
+  void reLoadImage() {}
+
+  Widget _buildGestureWidget() {
+    return ExtendedImageGesture(
+      this,
+      key: widget.extendedImageGestureKey,
+      canScaleImage: widget.canScaleImage,
+      imageBuilder:
+          (Widget image, {ExtendedImageGestureState? imageGestureState}) {
+            return imageGestureState!.wrapGestureWidget(
+              widget.child,
+              imageWidth: widget.childSize.width,
+              imageHeight: widget.childSize.height,
+              imageFit: widget.fit,
+              alignment: widget.alignment,
+            );
+          },
+    );
+  }
+
+  ExtendedImage _buildImageWidget() {
+    return ExtendedImage(
+      image: _transparentImageProvider,
+      semanticLabel: widget.semanticLabel,
+      excludeFromSemantics: widget.excludeFromSemantics,
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit,
+      alignment: widget.alignment,
+      mode: ExtendedImageMode.gesture,
+      onDoubleTap: widget.onDoubleTap,
+      initGestureConfigHandler: widget.initGestureConfigHandler,
+      enableSlideOutPage: widget.enableSlideOutPage,
+      constraints: widget.constraints,
+      heroBuilderForSlidingPage: widget.heroBuilderForSlidingPage,
+      extendedImageGestureKey: widget.extendedImageGestureKey,
+    );
+  }
+
+  void _updateSlidePageState() {
+    _slidePageState = widget.enableSlideOutPage
+        ? context.findAncestorStateOfType<ExtendedImageSlidePageState>()
+        : null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,11 @@ dependencies:
     sdk: flutter
   meta: ^1.7.0
   vector_math: ^2.1.4
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
 dependency_overrides:
   # extended_image_library:
   #   path: ../extended_image_library

--- a/test/extended_image_gesture_widget_test.dart
+++ b/test/extended_image_gesture_widget_test.dart
@@ -1,0 +1,72 @@
+import 'package:extended_image/extended_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('lays out a custom child with the provided size and fit', (
+    WidgetTester tester,
+  ) async {
+    const Key viewportKey = ValueKey<String>('viewport');
+    const Key childKey = ValueKey<String>('custom-child');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            key: viewportKey,
+            width: 300,
+            height: 200,
+            child: ExtendedImageGestureWidget(
+              childSize: const Size(100, 50),
+              fit: BoxFit.contain,
+              child: const ColoredBox(key: childKey, color: Colors.red),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(childKey)), const Size(300, 150));
+    expect(
+      tester.getTopLeft(find.byKey(childKey)) -
+          tester.getTopLeft(find.byKey(viewportKey)),
+      const Offset(0, 25),
+    );
+  });
+
+  testWidgets('zooms a custom child through ExtendedImageGestureState', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey<ExtendedImageGestureState> gestureKey =
+        GlobalKey<ExtendedImageGestureState>();
+    const Key viewportKey = ValueKey<String>('viewport');
+    const Key childKey = ValueKey<String>('custom-child');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            key: viewportKey,
+            width: 300,
+            height: 200,
+            child: ExtendedImageGestureWidget(
+              extendedImageGestureKey: gestureKey,
+              childSize: const Size(100, 50),
+              fit: BoxFit.contain,
+              child: const ColoredBox(key: childKey, color: Colors.blue),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    gestureKey.currentState!.handleDoubleTap(
+      scale: 2,
+      doubleTapPosition: tester.getCenter(find.byKey(viewportKey)),
+    );
+    await tester.pump();
+
+    expect(gestureKey.currentState!.gestureDetails!.totalScale, 2);
+    expect(tester.getSize(find.byKey(childKey)), const Size(600, 300));
+  });
+}


### PR DESCRIPTION
## Summary
- Add `ExtendedImageGestureWidget` so arbitrary widget trees can use the existing gesture, page-view, slide-page, double-tap, and Hero behavior.
- Extend the gesture widget delegate with alignment support for custom fitted content while preserving current image-provider behavior.
- Document and demo widget content such as SVGs without rasterizing to image bytes.

## Test plan
- [x] `flutter analyze --no-pub lib/src/gesture/gesture.dart lib/src/gesture/gesture_widget.dart lib/extended_image.dart test/extended_image_gesture_widget_test.dart example/lib/pages/simple/zoom_image_demo.dart`
- [x] `flutter test --no-pub test`

Closes #762 , #118 , #301 